### PR TITLE
Support passing the result of one task into other tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ import (
 
 func doSomething(ctx context.Context) {
 
-    taskGraph, err := workflow.NewGraph([]workflow.Task{
-        NewTask("taskName", []string{"someOtherTask"}, func(ctx context.Context) error {
+    taskGraph, err := workflow.NewGraph(
+        NewTask("taskOne", []string{"taskTwo"}, func(ctx context.Context, res Results) (interface{}, error) {
             // Do some useful work here...
-            return nil
+            return nil, nil
         }),
-        NewTask("someOtherTask", nil, func(ctx context.Context) error {
+        NewTask("taskTwo", nil, func(ctx context.Context, res Results) (interface{}, error) {
             // Do some useful work here...
-            return nil
+            return nil, nil
         })
-    })
+    )
 
-    // Check for an error in case we forgot to add "someOtherTask" as a dependency to "taskName"
+    // Check for an error -- maybe we forgot to add "taskTwo"
     if err != nil {
         // Handle the error ....
     }

--- a/doc.go
+++ b/doc.go
@@ -19,19 +19,18 @@
 //	 )
 //
 //	 func doSomething(ctx context.Context) {
-//
-//	 	taskGraph, err := workflow.NewGraph([]workflow.Task{
-//	 		NewTask("taskName", []string{"someOtherTask"}, func(ctx context.Context) error {
+//	 	taskGraph, err := workflow.NewGraph(
+//	 		NewTask("taskName", []string{"someOtherTask"}, func(ctx context.Context, res Results) (interface{}, error) {
 //	 			// Do some useful work here...
-//	 			return nil
+//	 			return nil, nil
 //	 		}),
-//	 		NewTask("someOtherTask", nil, func(ctx context.Context) error {
+//	 		NewTask("someOtherTask", nil, func(ctx context.Context, res Results) (interface{}, error) {
 //	 			// Do some useful work here...
-//	 			return nil
+//	 			return nil, nil
 //	 		})
-//	 	})
+//	 	)
 //
-//	 	// Check for an error in case we forgot to add "someOtherTask" as a dependency to "taskName"
+//	 	// Check for an error constructing the graph
 //	 	if err != nil {
 //	 		// Handle the error ....
 //	 	}
@@ -42,9 +41,10 @@
 //	 }
 //
 // In this example, `taskName` will run before `someOtherTask` does, assuming
-// that `taskName` does not return an error.
-// If "taskName" returns an error, `taskGraph.Run()` will return an error and
-// `someOtherTask` will not execute.
+// that `taskName` does not return an error. `taskName` will also have the
+// result of `someOtherTask` included in the `Results` parameter.
+// If "someOtherTask" returns an error, `taskGraph.Run()` will return an error and
+// `taskName` will not execute.
 //
 // Currently, 2^32 - 1 tasks are supported per workflow.
 package workflow

--- a/execution_ctx.go
+++ b/execution_ctx.go
@@ -20,7 +20,7 @@ type executionCtx struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	errCounter    *atomic.Int32 // There are no atomic errors, sadly
-	results       *sync.Map
+	results       Results
 }
 
 func newExecutionCtx(ctx context.Context, g Graph) *executionCtx {
@@ -32,7 +32,7 @@ func newExecutionCtx(ctx context.Context, g Graph) *executionCtx {
 		ctx:           iCtx,
 		cancel:        cancel,
 		errCounter:    atomic.NewInt32(0),
-		results:       &sync.Map{},
+		results:       Results{resMap: &sync.Map{}},
 	}
 }
 
@@ -87,7 +87,7 @@ func (ec *executionCtx) runTask(t Task) {
 		return
 	}
 
-	ec.results.Store(t.name, res)
+	ec.results.store(t.name, res)
 
 	for dep := range ec.g.taskToDependants[t.name] {
 		if ec.taskToNumdeps[dep].Add(-1) == int32(0) {

--- a/execution_ctx.go
+++ b/execution_ctx.go
@@ -20,6 +20,7 @@ type executionCtx struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	errCounter    *atomic.Int32 // There are no atomic errors, sadly
+	results       *sync.Map
 }
 
 func newExecutionCtx(ctx context.Context, g Graph) *executionCtx {
@@ -31,6 +32,7 @@ func newExecutionCtx(ctx context.Context, g Graph) *executionCtx {
 		ctx:           iCtx,
 		cancel:        cancel,
 		errCounter:    atomic.NewInt32(0),
+		results:       &sync.Map{},
 	}
 }
 
@@ -78,11 +80,14 @@ func (ec *executionCtx) runTask(t Task) {
 		return
 	}
 
-	if err := t.fn(ec.ctx); err != nil {
+	res, err := t.fn(ec.ctx, ec.results)
+	if err != nil {
 		ec.markFailure(err)
 		// Do not queue up additional tasks after encountering an error
 		return
 	}
+
+	ec.results.Store(t.name, res)
 
 	for dep := range ec.g.taskToDependants[t.name] {
 		if ec.taskToNumdeps[dep].Add(-1) == int32(0) {

--- a/results.go
+++ b/results.go
@@ -1,0 +1,19 @@
+package workflow
+
+import "sync"
+
+// Results holds a reference to the intermediate results of a workflow
+// execution. It used to task the result of one function into its
+// dependencies.
+type Results struct {
+	resMap *sync.Map
+}
+
+// Load retrieves the result for a particular task.
+func (r Results) Load(taskName string) (val interface{}, ok bool) {
+	return r.resMap.Load(taskName)
+}
+
+func (r Results) store(taskName string, result interface{}) {
+	r.resMap.Store(taskName, result)
+}

--- a/workflow.go
+++ b/workflow.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"sync"
 )
 
 var empty struct{}
@@ -9,7 +10,8 @@ var empty struct{}
 // A TaskFn is an individually executable unit of work. It is expected that
 // when the context is closed, such as via a timetout or cancellation, that
 // a TaskFun will cease execution and return immediately.
-type TaskFn = func(ctx context.Context) error
+// Results, which can be nil, contains a map of task name to return result.
+type TaskFn = func(ctx context.Context, results *sync.Map) (interface{}, error)
 
 // A Task is a unit of work along with a name and set of dependencies.
 type Task struct {

--- a/workflow.go
+++ b/workflow.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"sync"
 )
 
 var empty struct{}
@@ -11,7 +10,7 @@ var empty struct{}
 // when the context is closed, such as via a timetout or cancellation, that
 // a TaskFun will cease execution and return immediately.
 // Results, which can be nil, contains a map of task name to return result.
-type TaskFn = func(ctx context.Context, results *sync.Map) (interface{}, error)
+type TaskFn = func(ctx context.Context, results Results) (interface{}, error)
 
 // A Task is a unit of work along with a name and set of dependencies.
 type Task struct {
@@ -52,7 +51,7 @@ type Graph struct {
 // well-formed, such as when a dependency is not satisfied or a cycle is
 // detected.
 func NewGraph(
-	tasks []Task,
+	tasks ...Task,
 ) (Graph, error) {
 	taskMap := make(map[string]Task, len(tasks))
 	taskToDependants := make(map[string]map[string]struct{}, len(tasks))

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -3,12 +3,11 @@ package workflow
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 )
 
 func TestWorkflowNoJobs(t *testing.T) {
-	graph, err := NewGraph(nil)
+	graph, err := NewGraph()
 
 	if err != nil {
 		t.Fatal("failed to initialize the graph")
@@ -26,16 +25,16 @@ func TestWorkflowSimpleCase(t *testing.T) {
 	taskTwoRan := false
 	taskThreeRan := false
 	taskOneRetVal := "someReturnValue"
-	taskGraph, err := NewGraph([]Task{
-		NewTask("taskOne", []string{"taskTwo"}, func(ctx context.Context, res *sync.Map) (interface{}, error) {
+	taskGraph, err := NewGraph(
+		NewTask("taskOne", []string{"taskTwo"}, func(ctx context.Context, res Results) (interface{}, error) {
 			taskOneRan = true
 			return taskOneRetVal, nil
 		}),
-		NewTask("taskTwo", nil, func(ctx context.Context, res *sync.Map) (interface{}, error) {
+		NewTask("taskTwo", nil, func(ctx context.Context, res Results) (interface{}, error) {
 			taskTwoRan = true
 			return nil, nil
 		}),
-		NewTask("taskThree", []string{"taskOne"}, func(ctx context.Context, res *sync.Map) (interface{}, error) {
+		NewTask("taskThree", []string{"taskOne"}, func(ctx context.Context, res Results) (interface{}, error) {
 			taskThreeRan = true
 
 			taskOneRes, ok := res.Load("taskOne")
@@ -54,7 +53,7 @@ func TestWorkflowSimpleCase(t *testing.T) {
 
 			return nil, nil
 		}),
-	})
+	)
 
 	if err != nil {
 		t.Fatal("failed to initialize the graph")
@@ -82,16 +81,16 @@ func TestWorkflowReturnsError(t *testing.T) {
 	retErr := errors.New("bad error")
 	taskOneRan := false
 	taskTwoRan := false
-	taskGraph, err := NewGraph([]Task{
-		NewTask("taskName", []string{"someOtherTask"}, func(ctx context.Context, res *sync.Map) (interface{}, error) {
+	taskGraph, err := NewGraph(
+		NewTask("taskName", []string{"someOtherTask"}, func(ctx context.Context, res Results) (interface{}, error) {
 			taskOneRan = true
 			return nil, nil
 		}),
-		NewTask("someOtherTask", nil, func(ctx context.Context, res *sync.Map) (interface{}, error) {
+		NewTask("someOtherTask", nil, func(ctx context.Context, res Results) (interface{}, error) {
 			taskTwoRan = true
 			return nil, retErr
 		}),
-	})
+	)
 
 	if err != nil {
 		t.Fatal("failed to initialize the graph")


### PR DESCRIPTION
This PR changes the function signature of the task function to both return an empty interface and accept a new Results type. This type is a simple struct that holds a reference to a `sync.Map`, letting each task atomically and concurrently write their results and retrieve the results in later tasks.

The idea is that, currently, users of this library have to declare variables global to a function to pass data around. While this has maximum type safety, it is also somewhat cumbersome, and introduces the possible error of forgetting to set a vale.

This PR makes a different trade-off. It argues that strict type safety is slightly overrated in the absence of polymorphic parametricity. Personally I'd rather be able to do `NewGraph<ResultTypeHere>(....)` a la Java but if Go is Java 1.4 might as well unleash the power of casting before contracts.